### PR TITLE
Add .contents to ServiceInstallCtx to use in place of the make_* templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [0.3.0] - 2023-06-08
+
+### Added
+
+- Add .contents to ServiceInstallCtx to use in place of the make_* templates
+  This is a backwards incompatible change.
+
 ## [0.1.3] - 2022-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ manager.install(ServiceInstallCtx {
     label: label.clone(),
     program: PathBuf::from("path/to/my-service-executable"),
     args: vec![OsString::from("--some-arg")],
+    content: None, // Optional String for system-specific service content.
 }).expect("Failed to install");
 
 // Start our service using the underlying service management platform
@@ -130,6 +131,7 @@ manager.install(ServiceInstallCtx {
     label: label.clone(),
     program: PathBuf::from("path/to/my-service-executable"),
     args: vec![OsString::from("--some-arg")],
+    content: None, // Optional String for system-specific service content.
 }).expect("Failed to install");
 ```
 

--- a/src/launchd.rs
+++ b/src/launchd.rs
@@ -97,7 +97,10 @@ impl ServiceManager for LaunchdServiceManager {
 
         let qualified_name = ctx.label.to_qualified_name();
         let plist_path = dir_path.join(format!("{}.plist", qualified_name));
-        let plist = make_plist(&self.config.install, &qualified_name, ctx.cmd_iter());
+        let plist = match ctx.contents {
+            Some(contents) => contents,
+            _ => make_plist(&self.config.install, &qualified_name, ctx.cmd_iter()),
+        };
 
         utils::write_file(
             plist_path.as_path(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,12 @@ impl dyn ServiceManager {
     }
 }
 
-
-    /// Attempts to select a native service manager for the current operating system1
-    ///
-    /// * For MacOS, this will use [`LaunchdServiceManager`]
-    /// * For Windows, this will use [`ScServiceManager`]
-    /// * For BSD variants, this will use [`RcdServiceManager`]
-    /// * For Linux variants, this will use either [`SystemdServiceManager`] or [`OpenRcServiceManager`]
+/// Attempts to select a native service manager for the current operating system1
+///
+/// * For MacOS, this will use [`LaunchdServiceManager`]
+/// * For Windows, this will use [`ScServiceManager`]
+/// * For BSD variants, this will use [`RcdServiceManager`]
+/// * For Linux variants, this will use either [`SystemdServiceManager`] or [`OpenRcServiceManager`]
 #[inline]
 pub fn native_service_manager() -> io::Result<Box<dyn ServiceManager>> {
     Ok(TypedServiceManager::native()?.into_box())
@@ -123,7 +122,7 @@ pub struct ServiceLabel {
 impl ServiceLabel {
     /// Produces a fully-qualified name in the form of `{qualifier}.{organization}.{application}`
     pub fn to_qualified_name(&self) -> String {
-        let mut qualified_name = String::new(); 
+        let mut qualified_name = String::new();
         if let Some(qualifier) = self.qualifier.as_ref() {
             qualified_name.push_str(qualifier.as_str());
             qualified_name.push('.');
@@ -182,8 +181,8 @@ impl FromStr for ServiceLabel {
             _ => Self {
                 qualifier: Some(tokens[0].to_string()),
                 organization: Some(tokens[1].to_string()),
-                application: (&tokens[2..]).join("."),
-            }
+                application: tokens[2..].join("."),
+            },
         };
 
         Ok(label)
@@ -206,6 +205,10 @@ pub struct ServiceInstallCtx {
     ///
     /// E.g. `--arg`, `value`, `--another-arg`
     pub args: Vec<OsString>,
+
+    /// Optional contents of the service file for a given ServiceManager
+    /// to use instead of the default template.
+    pub contents: Option<String>,
 }
 
 impl ServiceInstallCtx {
@@ -243,7 +246,6 @@ pub struct ServiceStopCtx {
     /// E.g. `rocks.distant.manager`
     pub label: ServiceLabel,
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -284,5 +286,4 @@ mod tests {
         assert_eq!(label.to_qualified_name(), "app123");
         assert_eq!(label.to_script_name(), "app123");
     }
-
 }

--- a/src/openrc.rs
+++ b/src/openrc.rs
@@ -54,12 +54,15 @@ impl ServiceManager for OpenRcServiceManager {
         let script_name = ctx.label.to_script_name();
         let script_path = dir_path.join(&script_name);
 
-        let script = make_script(
-            &script_name,
-            &script_name,
-            ctx.program.as_os_str(),
-            ctx.args,
-        );
+        let script = match ctx.contents {
+            Some(contents) => contents,
+            _ => make_script(
+                &script_name,
+                &script_name,
+                ctx.program.as_os_str(),
+                ctx.args,
+            ),
+        };
 
         utils::write_file(
             script_path.as_path(),

--- a/src/rcd.rs
+++ b/src/rcd.rs
@@ -48,7 +48,10 @@ impl ServiceManager for RcdServiceManager {
 
     fn install(&self, ctx: ServiceInstallCtx) -> io::Result<()> {
         let service = ctx.label.to_script_name();
-        let script = make_script(&service, &service, ctx.program.as_os_str(), ctx.args);
+        let script = match ctx.contents {
+            Some(contents) => contents,
+            _ => make_script(&service, &service, ctx.program.as_os_str(), ctx.args),
+        };
 
         utils::write_file(
             &rc_d_script_path(&service),

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -135,13 +135,16 @@ impl ServiceManager for SystemdServiceManager {
 
         let script_name = ctx.label.to_script_name();
         let script_path = dir_path.join(format!("{script_name}.service"));
-        let service = make_service(
-            &self.config.install,
-            &script_name,
-            ctx.program.into_os_string(),
-            ctx.args,
-            self.user,
-        );
+        let service = match ctx.contents {
+            Some(contents) => contents,
+            _ => make_service(
+                &self.config.install,
+                &script_name,
+                ctx.program.into_os_string(),
+                ctx.args,
+                self.user,
+            ),
+        };
 
         utils::write_file(
             script_path.as_path(),

--- a/system-tests/tests/runner.rs
+++ b/system-tests/tests/runner.rs
@@ -61,6 +61,7 @@ pub fn run_test(manager: &TypedServiceManager) {
                     .join(format!("{service_label}.log"))
                     .into_os_string(),
             ],
+            contents: None,
         })
         .unwrap();
 


### PR DESCRIPTION
This is a backwards incompatible change as there is no "fn new" function or similar for creating a ServiceInstallCtx instance.

Fixes #6 

Let me know what you think. 