### PR TITLE
Provide WinSW Service Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
   tests:
     name: "Test Rust ${{ matrix.rust }} for ${{ matrix.test }} w/ ${{ matrix.manager }} (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    env:
+      WINSW_URL: https://github.com/winsw/winsw/releases/download/v3.0.0-alpha.11/WinSW-x64.exe
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +55,7 @@ jobs:
           - { rust: stable, os: macos-latest, manager: launchd, test: launchd_for_user }
           - { rust: stable, os: macos-latest, manager: launchd, test: launchd_for_system, elevated: sudo }
           - { rust: stable, os: windows-latest, manager: sc, test: sc_for_system }
+          - { rust: stable, os: windows-latest, manager: winsw, test: winsw_for_system }
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.rust }}
@@ -60,6 +63,15 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+
+      - name: Download WinSW for Windows
+        if: matrix.os == 'windows-latest' && matrix.manager == 'winsw'
+        run: |
+          $winsw_dir = "$env:GITHUB_WORKSPACE\winsw"
+          New-Item -ItemType directory -Path $winsw_dir -Force
+          Invoke-WebRequest -Uri ${{ env.WINSW_URL }} -OutFile "$winsw_dir\WinSW.exe"
+          echo "$winsw_dir" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_PATH
+
       - uses: Swatinem/rust-cache@v1
       - name: Run ${{ matrix.test }} for ${{ matrix.manager }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [0.5.0] - 2023-11-03
+
+- Support for the WinSW service manager was added. WinSW can run any
+  application as a Windows service by providing the boilerplate code for
+  interacting with the Windows service infrastructure. Most, but not all,
+  configuration options are supported in this initial setup.
+- The `ServiceInstallCtx` is extended with optional `working_directory` and
+  `environment` fields, which assign a working directory and pass a list of
+  environment variables to the process launched by the service. Most service
+  managers support these. This is a backwards incompatible change.
+
 ## [0.4.0] - 2023-10-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,9 @@ dirs = "4.0"
 plist = "1.1"
 serde = { version = "1", features = ["derive"], optional = true }
 which = "4.0"
+xml-rs = "0.8.19"
+
+[dev-dependencies]
+assert_fs = "1.0.13"
+indoc = "2.0.4"
+predicates = "3.0.4"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ manager.install(ServiceInstallCtx {
     args: vec![OsString::from("--some-arg")],
     contents: None, // Optional String for system-specific service content.
     username: None, // Optional String for alternative user to run service.
+    working_directory: None, // Optional String for the working directory for the service process.
+    environment: None, // Optional list of environment variables to supply the service process.
 }).expect("Failed to install");
 
 // Start our service using the underlying service management platform
@@ -137,6 +139,8 @@ manager.install(ServiceInstallCtx {
     args: vec![OsString::from("--some-arg")],
     contents: None, // Optional String for system-specific service content.
     username: None, // Optional String for alternative user to run service.
+    working_directory: None, // Optional String for the working directory for the service process.
+    environment: None, // Optional list of environment variables to supply the service process.
 }).expect("Failed to install");
 ```
 

--- a/src/launchd.rs
+++ b/src/launchd.rs
@@ -106,6 +106,8 @@ impl ServiceManager for LaunchdServiceManager {
                 &qualified_name,
                 ctx.cmd_iter(),
                 ctx.username.clone(),
+                ctx.working_directory.clone(),
+                ctx.environment.clone(),
             ),
         };
 
@@ -200,6 +202,8 @@ fn make_plist<'a>(
     label: &str,
     args: impl Iterator<Item = &'a OsStr>,
     username: Option<String>,
+    working_directory: Option<PathBuf>,
+    environment: Option<Vec<(String, String)>>,
 ) -> String {
     let mut dict = Dictionary::new();
 
@@ -217,6 +221,24 @@ fn make_plist<'a>(
 
     if let Some(username) = username {
         dict.insert("UserName".to_string(), Value::String(username));
+    }
+
+    if let Some(working_dir) = working_directory {
+        dict.insert(
+            "WorkingDirectory".to_string(),
+            Value::String(working_dir.to_string_lossy().to_string()),
+        );
+    }
+
+    if let Some(env_vars) = environment {
+        let env_dict: Dictionary = env_vars
+            .into_iter()
+            .map(|(k, v)| (k, Value::String(v)))
+            .collect();
+        dict.insert(
+            "EnvironmentVariables".to_string(),
+            Value::Dictionary(env_dict),
+        );
     }
 
     let plist = Value::Dictionary(dict);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod sc;
 mod systemd;
 mod typed;
 mod utils;
+mod winsw;
 
 pub use kind::*;
 pub use launchd::*;
@@ -27,6 +28,7 @@ pub use rcd::*;
 pub use sc::*;
 pub use systemd::*;
 pub use typed::*;
+pub use winsw::*;
 
 /// Interface for a service manager
 pub trait ServiceManager {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,13 @@ pub struct ServiceInstallCtx {
     ///
     /// If not specified, the service will run as the root or Administrator user.
     pub username: Option<String>,
+
+    /// Optionally specify a working directory for the process launched by the service
+    pub working_directory: Option<PathBuf>,
+
+    /// Optionally specify a list of environment variables to be passed to the process launched by
+    /// the service
+    pub environment: Option<Vec<(String, String)>>,
 }
 
 impl ServiceInstallCtx {

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,7 +1,7 @@
 use super::{
     LaunchdServiceManager, OpenRcServiceManager, RcdServiceManager, ScServiceManager,
     ServiceInstallCtx, ServiceLevel, ServiceManager, ServiceManagerKind, ServiceStartCtx,
-    ServiceStopCtx, ServiceUninstallCtx, SystemdServiceManager,
+    ServiceStopCtx, ServiceUninstallCtx, SystemdServiceManager, WinSwServiceManager,
 };
 use std::io;
 
@@ -13,6 +13,7 @@ pub enum TypedServiceManager {
     Rcd(RcdServiceManager),
     Sc(ScServiceManager),
     Systemd(SystemdServiceManager),
+    WinSw(WinSwServiceManager),
 }
 
 macro_rules! using {
@@ -23,6 +24,7 @@ macro_rules! using {
             TypedServiceManager::Rcd($this) => $expr,
             TypedServiceManager::Sc($this) => $expr,
             TypedServiceManager::Systemd($this) => $expr,
+            TypedServiceManager::WinSw($this) => $expr,
         }
     }};
 }
@@ -76,6 +78,7 @@ impl TypedServiceManager {
             ServiceManagerKind::Rcd => Self::Rcd(RcdServiceManager::default()),
             ServiceManagerKind::Sc => Self::Sc(ScServiceManager::default()),
             ServiceManagerKind::Systemd => Self::Systemd(SystemdServiceManager::default()),
+            ServiceManagerKind::WinSw => Self::WinSw(WinSwServiceManager::default()),
         }
     }
 
@@ -118,6 +121,11 @@ impl TypedServiceManager {
     pub fn is_systemd(&self) -> bool {
         matches!(self, Self::Systemd(_))
     }
+
+    /// Returns true if [`ServiceManager`] instance is for `winsw`
+    pub fn is_winsw(&self) -> bool {
+        matches!(self, Self::WinSw(_))
+    }
 }
 
 impl From<super::LaunchdServiceManager> for TypedServiceManager {
@@ -147,5 +155,11 @@ impl From<super::ScServiceManager> for TypedServiceManager {
 impl From<super::SystemdServiceManager> for TypedServiceManager {
     fn from(manager: super::SystemdServiceManager) -> Self {
         Self::Systemd(manager)
+    }
+}
+
+impl From<super::WinSwServiceManager> for TypedServiceManager {
+    fn from(manager: super::WinSwServiceManager) -> Self {
+        Self::WinSw(manager)
     }
 }

--- a/src/winsw.rs
+++ b/src/winsw.rs
@@ -1,0 +1,714 @@
+use super::{
+    ServiceInstallCtx, ServiceLevel, ServiceManager, ServiceStartCtx, ServiceStopCtx,
+    ServiceUninstallCtx,
+};
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{self, BufWriter, Cursor, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use xml::common::XmlVersion;
+use xml::reader::EventReader;
+use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
+
+static WINSW_EXE: &str = "winsw.exe";
+
+///
+/// Service configuration
+///
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WinSwConfig {
+    pub install: WinSwInstallConfig,
+    pub options: WinSwOptionsConfig,
+    pub service_definition_dir_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WinSwInstallConfig {
+    pub failure_action: WinSwOnFailureAction,
+    pub reset_failure_time: Option<String>,
+    pub security_descriptor: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WinSwOptionsConfig {
+    pub priority: Option<WinSwPriority>,
+    pub stop_timeout: Option<String>,
+    pub stop_executable: Option<PathBuf>,
+    pub stop_args: Option<Vec<OsString>>,
+    pub start_mode: Option<WinSwStartType>,
+    pub delayed_autostart: Option<bool>,
+    pub dependent_services: Option<Vec<String>>,
+    pub interactive: Option<bool>,
+    pub beep_on_shutdown: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum WinSwOnFailureAction {
+    Restart(Option<String>),
+    Reboot,
+    #[default]
+    None,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WinSwStartType {
+    // The service automatically starts along with the OS, before user login.
+    Automatic,
+    /// The service is a device driver loaded by the boot loader.
+    Boot,
+    /// The service must be started manually.
+    Manual,
+    /// The service is a device driver started during kernel initialization.
+    System,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum WinSwPriority {
+    #[default]
+    Normal,
+    Idle,
+    High,
+    RealTime,
+    BelowNormal,
+    AboveNormal,
+}
+
+///
+/// Service manager implementation
+///
+
+/// Implementation of [`ServiceManager`] for [Window Service](https://en.wikipedia.org/wiki/Windows_service)
+/// leveraging [`winsw.exe`](https://github.com/winsw/winsw)
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WinSwServiceManager {
+    pub config: WinSwConfig,
+}
+
+impl WinSwServiceManager {
+    pub fn system() -> Self {
+        let config = WinSwConfig {
+            install: WinSwInstallConfig::default(),
+            options: WinSwOptionsConfig::default(),
+            service_definition_dir_path: PathBuf::from("C:\\ProgramData\\service-manager"),
+        };
+        Self { config }
+    }
+
+    pub fn with_config(self, config: WinSwConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn write_service_configuration(
+        path: &PathBuf,
+        ctx: &ServiceInstallCtx,
+        config: &WinSwConfig,
+    ) -> io::Result<()> {
+        let mut file = File::create(path).unwrap();
+        if let Some(contents) = &ctx.contents {
+            if Self::is_valid_xml(contents) {
+                file.write_all(contents.as_bytes())?;
+                return Ok(());
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "The contents override was not a valid XML document",
+            ));
+        }
+
+        let file = BufWriter::new(file);
+        let mut writer = EmitterConfig::new()
+            .perform_indent(true)
+            .create_writer(file);
+        writer
+            .write(XmlEvent::StartDocument {
+                version: XmlVersion::Version10,
+                encoding: Some("UTF-8"),
+                standalone: None,
+            })
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Writing service config failed: {}", e),
+                )
+            })?;
+
+        // <service>
+        writer
+            .write(XmlEvent::start_element("service"))
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Writing service config failed: {}", e),
+                )
+            })?;
+
+        // Mandatory values
+        Self::write_element(&mut writer, "id", &ctx.label.to_qualified_name())?;
+        Self::write_element(&mut writer, "name", &ctx.label.to_qualified_name())?;
+        Self::write_element(&mut writer, "executable", &ctx.program.to_string_lossy())?;
+        Self::write_element(
+            &mut writer,
+            "description",
+            &format!("Service for {}", ctx.label.to_qualified_name()),
+        )?;
+        let args = ctx
+            .args
+            .clone()
+            .into_iter()
+            .map(|s| s.into_string().unwrap_or_default())
+            .collect::<Vec<String>>()
+            .join(" ");
+        Self::write_element(&mut writer, "arguments", &args)?;
+
+        // Optional install elements
+        let (action, delay) = match &config.install.failure_action {
+            WinSwOnFailureAction::Restart(delay) => ("restart", delay.as_deref()),
+            WinSwOnFailureAction::Reboot => ("reboot", None),
+            WinSwOnFailureAction::None => ("none", None),
+        };
+        let attributes = delay.map_or_else(
+            || vec![("action", action)],
+            |d| vec![("action", action), ("delay", d)],
+        );
+        Self::write_element_with_attributes(&mut writer, "onfailure", &attributes, None)?;
+
+        if let Some(reset_time) = &config.install.reset_failure_time {
+            Self::write_element(&mut writer, "resetfailure", reset_time)?;
+        }
+        if let Some(security_descriptor) = &config.install.security_descriptor {
+            Self::write_element(&mut writer, "securityDescriptor", security_descriptor)?;
+        }
+
+        // Other optional elements
+        if let Some(priority) = &config.options.priority {
+            Self::write_element(&mut writer, "priority", &format!("{:?}", priority))?;
+        }
+        if let Some(stop_timeout) = &config.options.stop_timeout {
+            Self::write_element(&mut writer, "stoptimeout", stop_timeout)?;
+        }
+        if let Some(stop_executable) = &config.options.stop_executable {
+            Self::write_element(
+                &mut writer,
+                "stopexecutable",
+                &stop_executable.to_string_lossy(),
+            )?;
+        }
+        if let Some(stop_args) = &config.options.stop_args {
+            let stop_args = stop_args
+                .iter()
+                .map(|s| s.to_string_lossy().into_owned())
+                .collect::<Vec<String>>()
+                .join(" ");
+            Self::write_element(&mut writer, "stoparguments", &stop_args)?;
+        }
+        if let Some(start_mode) = &config.options.start_mode {
+            Self::write_element(&mut writer, "startmode", &format!("{:?}", start_mode))?;
+        }
+        if let Some(delayed_autostart) = config.options.delayed_autostart {
+            Self::write_element(
+                &mut writer,
+                "delayedAutoStart",
+                &delayed_autostart.to_string(),
+            )?;
+        }
+        if let Some(dependent_services) = &config.options.dependent_services {
+            for service in dependent_services {
+                Self::write_element(&mut writer, "depend", service)?;
+            }
+        }
+        if let Some(interactive) = config.options.interactive {
+            Self::write_element(&mut writer, "interactive", &interactive.to_string())?;
+        }
+        if let Some(beep_on_shutdown) = config.options.beep_on_shutdown {
+            Self::write_element(&mut writer, "beeponshutdown", &beep_on_shutdown.to_string())?;
+        }
+
+        // </service>
+        writer.write(XmlEvent::end_element()).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Writing service config failed: {}", e),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn write_element<W: Write>(
+        writer: &mut EventWriter<W>,
+        name: &str,
+        value: &str,
+    ) -> io::Result<()> {
+        writer.write(XmlEvent::start_element(name)).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to write element '{}': {}", name, e),
+            )
+        })?;
+        writer.write(XmlEvent::characters(value)).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to write value for element '{}': {}", name, e),
+            )
+        })?;
+        writer.write(XmlEvent::end_element()).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to end element '{}': {}", name, e),
+            )
+        })?;
+        Ok(())
+    }
+
+    fn write_element_with_attributes<W: Write>(
+        writer: &mut EventWriter<W>,
+        name: &str,
+        attributes: &[(&str, &str)],
+        value: Option<&str>,
+    ) -> io::Result<()> {
+        let mut start_element = XmlEvent::start_element(name);
+        for &(attr_name, attr_value) in attributes {
+            start_element = start_element.attr(attr_name, attr_value);
+        }
+        writer.write(start_element).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to write value for element '{}': {}", name, e),
+            )
+        })?;
+
+        if let Some(val) = value {
+            writer.write(XmlEvent::characters(val)).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to write value for element '{}': {}", name, e),
+                )
+            })?;
+        }
+
+        writer.write(XmlEvent::end_element()).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to end element '{}': {}", name, e),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn is_valid_xml(xml_string: &str) -> bool {
+        let cursor = Cursor::new(xml_string);
+        let parser = EventReader::new(cursor);
+        for e in parser {
+            if let Err(_) = e {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl ServiceManager for WinSwServiceManager {
+    fn available(&self) -> io::Result<bool> {
+        match which::which(WINSW_EXE) {
+            Ok(_) => Ok(true),
+            Err(which::Error::CannotFindBinaryPath) => Ok(false),
+            Err(x) => Err(io::Error::new(io::ErrorKind::Other, x)),
+        }
+    }
+
+    fn install(&self, ctx: ServiceInstallCtx) -> io::Result<()> {
+        let service_name = ctx.label.to_qualified_name();
+        let service_instance_path = self
+            .config
+            .service_definition_dir_path
+            .join(service_name.clone());
+        std::fs::create_dir_all(&service_instance_path)?;
+
+        let service_config_path = service_instance_path.join(&format!("{}.xml", service_name));
+        Self::write_service_configuration(&service_config_path, &ctx, &self.config)?;
+
+        winsw_exe("install", &service_name, service_instance_path)
+    }
+
+    fn uninstall(&self, ctx: ServiceUninstallCtx) -> io::Result<()> {
+        let service_name = ctx.label.to_qualified_name();
+        let service_instance_path = self
+            .config
+            .service_definition_dir_path
+            .join(service_name.clone());
+        winsw_exe("uninstall", &service_name, service_instance_path)
+    }
+
+    fn start(&self, ctx: ServiceStartCtx) -> io::Result<()> {
+        let service_name = ctx.label.to_qualified_name();
+        let service_instance_path = self
+            .config
+            .service_definition_dir_path
+            .join(service_name.clone());
+        winsw_exe("start", &service_name, service_instance_path)
+    }
+
+    fn stop(&self, ctx: ServiceStopCtx) -> io::Result<()> {
+        let service_name = ctx.label.to_qualified_name();
+        let service_instance_path = self
+            .config
+            .service_definition_dir_path
+            .join(service_name.clone());
+        winsw_exe("stop", &service_name, service_instance_path)
+    }
+
+    fn level(&self) -> ServiceLevel {
+        ServiceLevel::System
+    }
+
+    fn set_level(&mut self, level: ServiceLevel) -> io::Result<()> {
+        match level {
+            ServiceLevel::System => Ok(()),
+            ServiceLevel::User => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Windows does not support user-level services",
+            )),
+        }
+    }
+}
+
+fn winsw_exe<'a>(cmd: &str, service_name: &str, working_dir_path: PathBuf) -> io::Result<()> {
+    let mut command = Command::new(WINSW_EXE);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command.current_dir(working_dir_path);
+    command.arg(cmd).arg(&format!("{}.xml", service_name));
+
+    let output = command.output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let msg = String::from_utf8(output.stderr)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                String::from_utf8(output.stdout)
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .unwrap_or_else(|| format!("Failed to {cmd}"));
+
+        Err(io::Error::new(io::ErrorKind::Other, msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::prelude::*;
+    use indoc::indoc;
+    use std::ffi::OsString;
+    use std::io::Cursor;
+    use xml::reader::{EventReader, XmlEvent};
+
+    fn get_element_value(xml: &str, element_name: &str) -> String {
+        let cursor = Cursor::new(xml);
+        let parser = EventReader::new(cursor);
+        let mut inside_target_element = false;
+
+        for e in parser {
+            match e {
+                Ok(XmlEvent::StartElement { name, .. }) if name.local_name == element_name => {
+                    inside_target_element = true;
+                }
+                Ok(XmlEvent::Characters(text)) if inside_target_element => {
+                    return text;
+                }
+                Ok(XmlEvent::EndElement { name }) if name.local_name == element_name => {
+                    inside_target_element = false;
+                }
+                Err(e) => panic!("Error while parsing XML: {}", e),
+                _ => {}
+            }
+        }
+
+        panic!("Element {} not found", element_name);
+    }
+
+    fn get_element_attribute_value(xml: &str, element_name: &str, attribute_name: &str) -> String {
+        let cursor = Cursor::new(xml);
+        let parser = EventReader::new(cursor);
+
+        for e in parser {
+            match e {
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }) if name.local_name == element_name => {
+                    for attr in attributes {
+                        if attr.name.local_name == attribute_name {
+                            return attr.value;
+                        }
+                    }
+                }
+                Err(e) => panic!("Error while parsing XML: {}", e),
+                _ => {}
+            }
+        }
+
+        panic!("Attribute {} not found", attribute_name);
+    }
+
+    fn get_element_values(xml: &str, element_name: &str) -> Vec<String> {
+        let cursor = Cursor::new(xml);
+        let parser = EventReader::new(cursor);
+        let mut values = Vec::new();
+        let mut inside_target_element = false;
+
+        for e in parser {
+            match e {
+                Ok(XmlEvent::StartElement { name, .. }) if name.local_name == element_name => {
+                    inside_target_element = true;
+                }
+                Ok(XmlEvent::Characters(text)) if inside_target_element => {
+                    values.push(text);
+                }
+                Ok(XmlEvent::EndElement { name }) if name.local_name == element_name => {
+                    inside_target_element = false;
+                }
+                Err(e) => panic!("Error while parsing XML: {}", e),
+                _ => {}
+            }
+        }
+
+        values
+    }
+
+    #[test]
+    fn test_service_configuration_with_mandatory_elements() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let service_config_file = temp_dir.child("service_config.xml");
+
+        let ctx = ServiceInstallCtx {
+            label: "org.example.my_service".parse().unwrap(),
+            program: PathBuf::from("C:\\Program Files\\org.example\\my_service.exe"),
+            args: vec![
+                OsString::from("--arg"),
+                OsString::from("value"),
+                OsString::from("--another-arg"),
+            ],
+            contents: None,
+            username: None,
+        };
+
+        WinSwServiceManager::write_service_configuration(
+            &service_config_file.to_path_buf(),
+            &ctx,
+            &WinSwConfig::default(),
+        )
+        .unwrap();
+
+        let xml = std::fs::read_to_string(service_config_file.path()).unwrap();
+
+        service_config_file.assert(predicates::path::is_file());
+        assert_eq!("org.example.my_service", get_element_value(&xml, "id"));
+        assert_eq!("org.example.my_service", get_element_value(&xml, "name"));
+        assert_eq!(
+            "C:\\Program Files\\org.example\\my_service.exe",
+            get_element_value(&xml, "executable")
+        );
+        assert_eq!(
+            "Service for org.example.my_service",
+            get_element_value(&xml, "description")
+        );
+        assert_eq!(
+            "--arg value --another-arg",
+            get_element_value(&xml, "arguments")
+        );
+    }
+
+    #[test]
+    fn test_service_configuration_with_full_options() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let service_config_file = temp_dir.child("service_config.xml");
+
+        let ctx = ServiceInstallCtx {
+            label: "org.example.my_service".parse().unwrap(),
+            program: PathBuf::from("C:\\Program Files\\org.example\\my_service.exe"),
+            args: vec![
+                OsString::from("--arg"),
+                OsString::from("value"),
+                OsString::from("--another-arg"),
+            ],
+            contents: None,
+            username: None,
+        };
+
+        let config = WinSwConfig {
+            install: WinSwInstallConfig {
+                failure_action: WinSwOnFailureAction::Restart(Some("10 sec".to_string())),
+                reset_failure_time: Some("1 hour".to_string()),
+                security_descriptor: Some(
+                    "O:AOG:DAD:(A;;RPWPCCDCLCSWRCWDWOGA;;;S-1-0-0)".to_string(),
+                ),
+            },
+            options: WinSwOptionsConfig {
+                priority: Some(WinSwPriority::High),
+                stop_timeout: Some("15 sec".to_string()),
+                stop_executable: Some(PathBuf::from("C:\\Temp\\stop.exe")),
+                stop_args: Some(vec![
+                    OsString::from("--stop-arg1"),
+                    OsString::from("arg1val"),
+                    OsString::from("--stop-arg2-flag"),
+                ]),
+                start_mode: Some(WinSwStartType::Manual),
+                delayed_autostart: Some(true),
+                dependent_services: Some(vec!["service1".to_string(), "service2".to_string()]),
+                interactive: Some(true),
+                beep_on_shutdown: Some(true),
+            },
+            service_definition_dir_path: PathBuf::from("C:\\Temp\\service-definitions"),
+        };
+
+        WinSwServiceManager::write_service_configuration(
+            &service_config_file.to_path_buf(),
+            &ctx,
+            &config,
+        )
+        .unwrap();
+
+        let xml = std::fs::read_to_string(service_config_file.path()).unwrap();
+
+        service_config_file.assert(predicates::path::is_file());
+        assert_eq!("org.example.my_service", get_element_value(&xml, "id"));
+        assert_eq!("org.example.my_service", get_element_value(&xml, "name"));
+        assert_eq!(
+            "C:\\Program Files\\org.example\\my_service.exe",
+            get_element_value(&xml, "executable")
+        );
+        assert_eq!(
+            "Service for org.example.my_service",
+            get_element_value(&xml, "description")
+        );
+        assert_eq!(
+            "--arg value --another-arg",
+            get_element_value(&xml, "arguments")
+        );
+
+        // Install options
+        assert_eq!(
+            "restart",
+            get_element_attribute_value(&xml, "onfailure", "action")
+        );
+        assert_eq!(
+            "10 sec",
+            get_element_attribute_value(&xml, "onfailure", "delay")
+        );
+        assert_eq!("1 hour", get_element_value(&xml, "resetfailure"));
+        assert_eq!(
+            "O:AOG:DAD:(A;;RPWPCCDCLCSWRCWDWOGA;;;S-1-0-0)",
+            get_element_value(&xml, "securityDescriptor")
+        );
+
+        // Other options
+        assert_eq!("High", get_element_value(&xml, "priority"));
+        assert_eq!("15 sec", get_element_value(&xml, "stoptimeout"));
+        assert_eq!(
+            "C:\\Temp\\stop.exe",
+            get_element_value(&xml, "stopexecutable")
+        );
+        assert_eq!(
+            "--stop-arg1 arg1val --stop-arg2-flag",
+            get_element_value(&xml, "stoparguments")
+        );
+        assert_eq!("Manual", get_element_value(&xml, "startmode"));
+        assert_eq!("true", get_element_value(&xml, "delayedAutoStart"));
+
+        let dependent_services = get_element_values(&xml, "depend");
+        assert_eq!("service1", dependent_services[0]);
+        assert_eq!("service2", dependent_services[1]);
+
+        assert_eq!("true", get_element_value(&xml, "interactive"));
+        assert_eq!("true", get_element_value(&xml, "beeponshutdown"));
+    }
+
+    #[test]
+    fn test_service_configuration_with_contents() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let service_config_file = temp_dir.child("service_config.xml");
+
+        let contents = indoc! {r#"
+            <service>
+                <id>jenkins</id>
+                <name>Jenkins</name>
+                <description>This service runs Jenkins continuous integration system.</description>
+                <executable>java</executable>
+                <arguments>-Xrs -Xmx256m -jar "%BASE%\jenkins.war" --httpPort=8080</arguments>
+            </service>
+        "#};
+        let ctx = ServiceInstallCtx {
+            label: "org.example.my_service".parse().unwrap(),
+            program: PathBuf::from("C:\\Program Files\\org.example\\my_service.exe"),
+            args: vec![
+                OsString::from("--arg"),
+                OsString::from("value"),
+                OsString::from("--another-arg"),
+            ],
+            contents: Some(contents.to_string()),
+            username: None,
+        };
+
+        WinSwServiceManager::write_service_configuration(
+            &service_config_file.to_path_buf(),
+            &ctx,
+            &WinSwConfig::default(),
+        )
+        .unwrap();
+
+        let xml = std::fs::read_to_string(service_config_file.path()).unwrap();
+
+        service_config_file.assert(predicates::path::is_file());
+        assert_eq!("jenkins", get_element_value(&xml, "id"));
+        assert_eq!("Jenkins", get_element_value(&xml, "name"));
+        assert_eq!("java", get_element_value(&xml, "executable"));
+        assert_eq!(
+            "This service runs Jenkins continuous integration system.",
+            get_element_value(&xml, "description")
+        );
+        assert_eq!(
+            "-Xrs -Xmx256m -jar \"%BASE%\\jenkins.war\" --httpPort=8080",
+            get_element_value(&xml, "arguments")
+        );
+    }
+
+    #[test]
+    fn test_service_configuration_with_invalid_contents() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let service_config_file = temp_dir.child("service_config.xml");
+
+        let ctx = ServiceInstallCtx {
+            label: "org.example.my_service".parse().unwrap(),
+            program: PathBuf::from("C:\\Program Files\\org.example\\my_service.exe"),
+            args: vec![
+                OsString::from("--arg"),
+                OsString::from("value"),
+                OsString::from("--another-arg"),
+            ],
+            contents: Some("this is not an XML document".to_string()),
+            username: None,
+        };
+
+        let result = WinSwServiceManager::write_service_configuration(
+            &service_config_file.to_path_buf(),
+            &ctx,
+            &WinSwConfig::default(),
+        );
+
+        match result {
+            Ok(()) => panic!("This test should result in a failure"),
+            Err(e) => assert_eq!(
+                "The contents override was not a valid XML document",
+                e.to_string()
+            ),
+        }
+    }
+}

--- a/system-tests/tests/lib.rs
+++ b/system-tests/tests/lib.rs
@@ -5,7 +5,7 @@ mod runner;
 const TEST_ITER_CNT: usize = 3;
 
 #[test]
-// #[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
 fn should_support_launchd_for_system_services() {
     runner::run_test_n(LaunchdServiceManager::system(), TEST_ITER_CNT)
 }
@@ -63,6 +63,12 @@ fn should_support_rc_d_for_system_services() {
 #[cfg(target_os = "windows")]
 fn should_support_sc_for_system_services() {
     runner::run_test_n(ScServiceManager::system(), TEST_ITER_CNT)
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn should_support_winsw_for_system_services() {
+    runner::run_test_n(WinSwServiceManager::system(), TEST_ITER_CNT)
 }
 
 #[test]

--- a/system-tests/tests/runner.rs
+++ b/system-tests/tests/runner.rs
@@ -97,6 +97,8 @@ pub fn run_test(manager: &TypedServiceManager, username: Option<String>) -> Opti
             args,
             contents: None,
             username: username.clone(),
+            working_directory: None,
+            environment: None,
         })
         .unwrap();
 

--- a/system-tests/tests/runner.rs
+++ b/system-tests/tests/runner.rs
@@ -76,20 +76,25 @@ pub fn run_test(manager: &TypedServiceManager, username: Option<String>) -> Opti
     eprintln!("Checking if service available");
     assert!(manager.available().unwrap(), "Service not available");
 
+    let mut args = vec![
+        OsString::from("listen"),
+        OsString::from(addr.to_string()),
+        OsString::from("--log-file"),
+        std::env::temp_dir()
+            .join(format!("{service_label}.log"))
+            .into_os_string(),
+    ];
+    if manager.is_sc() {
+        args.push(OsString::from("--run-as-windows-service"));
+    }
+
     // Install the service
     eprintln!("Installing service");
     manager
         .install(ServiceInstallCtx {
             label: service_label.clone(),
             program: temp_bin_path,
-            args: vec![
-                OsString::from("listen"),
-                OsString::from(addr.to_string()),
-                OsString::from("--log-file"),
-                std::env::temp_dir()
-                    .join(format!("{service_label}.log"))
-                    .into_os_string(),
-            ],
+            args,
             contents: None,
             username: username.clone(),
         })


### PR DESCRIPTION
- 91bd9d0 **Provide the WinSW service manager**

  WinSW is a useful tool that can wrap any application as a Windows service; it provides the
  boilerplate code for interacting with the service infrastructure on Windows. You define a
  configuration for your application service in XML, then use WinSW, along with your configuration, as
  a service controller.

  The full specification for the service configuration can be found here:
  https://github.com/winsw/winsw/blob/v3/samples/complete.xml

  In this initial implementation, we provide support for most of the available elements, with the
  exception of:

  * serviceaccount
  * startarguments (I don't know what the difference is between that and 'arguments')
  * workingdirectory
  * logpath and log
  * env
  * download
  * extensions

  Support for workingdirectory and env will follow in subsequent commits; these fields can be added to
  the generic `ServiceInstallCtx` since they are common options on all platforms.

  Most of the code here deals with building the configuration file. This code was written as a
  separate function so that the different options could be unit tested. There is an integration/system
  test in a similar fashion to the sc manager.

- e1844e2 **Extend `ServiceInstallCtx` with new options**

  It is very common to define a working directory for a service process and a list of environment
  variables to pass to the process when it runs. The `ServiceInstallCtx` is extended for this because
  it applies to most service managers.

  In this particular case, three of the managers have been extended to support the variables: Systemd,
  Launchd and WinSW. The Windows `sc.exe` service manager does not support specifying either. The
  other two unix-based service managers might, but I am not familiar with those at the present time.
  It should be easy enough to extend them with a further PR.