### PR TITLE
Provide default implementation for WinSwConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [0.5.1] - 2023-11-22
+
+Fix a small issue in the WinSW service manager which caused the service
+management directories to be created at the current directory, rather than the
+intended location at C:\ProgramData\service-manager.
+
 ## [0.5.0] - 2023-11-06
 
 - Support for the WinSW service manager was added. WinSW can run any

--- a/src/winsw.rs
+++ b/src/winsw.rs
@@ -17,11 +17,21 @@ static WINSW_EXE: &str = "winsw.exe";
 /// Service configuration
 ///
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WinSwConfig {
     pub install: WinSwInstallConfig,
     pub options: WinSwOptionsConfig,
     pub service_definition_dir_path: PathBuf,
+}
+
+impl Default for WinSwConfig {
+    fn default() -> Self {
+        WinSwConfig {
+            install: WinSwInstallConfig::default(),
+            options: WinSwOptionsConfig::default(),
+            service_definition_dir_path: PathBuf::from("C:\\ProgramData\\service-manager"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
If this is not provided, when a new WinSW service manager is created, `service_definition_dir_path` will be set to an empty `PathBuf`, meaning the current directory will be used to store the service definitions.

The intention was for the service definitions to be stored at C:\ProgramData\service-manager.