### PR TITLE
fix(systemd): write environment variable to the service file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [0.5.1] - 2024-02-14
+
+- Introduced support for specifying environment variables for systemd.
+The specified variables are now written on separate lines.
+- Apply fixes suggested by clippy.
+
 ## [0.5.1] - 2023-11-22
 
 - Fix a small issue in the WinSW service manager which caused the service

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -267,6 +267,12 @@ fn make_service(
         );
     }
 
+    if let Some(env_vars) = &ctx.environment {
+        for (var, val) in env_vars {
+            let _ = writeln!(service, "Environment=\"{var}={val}\"");
+        }
+    }
+
     let program = ctx.program.to_string_lossy();
     let args = ctx
         .args

--- a/system-tests/tests/runner.rs
+++ b/system-tests/tests/runner.rs
@@ -107,14 +107,8 @@ pub fn run_test(manager: &TypedServiceManager, username: Option<String>) -> Opti
     // Wait for service to be installed
     wait();
 
-    let is_user_specified = if let Some(user) = username {
-        Some(is_service_using_the_specified_user(
-            &user,
-            service_label.clone(),
-        ))
-    } else {
-        None
-    };
+    let is_user_specified =
+        username.map(|user| is_service_using_the_specified_user(&user, service_label.clone()));
 
     // Start the service
     eprintln!("Starting service");


### PR DESCRIPTION
- The env variables were not actually set for the systemd services. This PR writes each of the provided env variables to the service file.

- Also, clippy was complaining about some tiny lint changes, so I've included them here. I can remove this commit if you feel like they're not actually adding anything. 