### PR TITLE
chore: derive basic traits on the service context structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [0.5.2] - 2024-02-16
+
+- Derive basic traits on the Service context structs.
+
 ## [0.5.1] - 2024-02-14
 
 - Introduced support for specifying environment variables for systemd.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ impl FromStr for ServiceLabel {
 }
 
 /// Context provided to the install function of [`ServiceManager`]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceInstallCtx {
     /// Label associated with the service
     ///
@@ -244,6 +245,7 @@ impl ServiceInstallCtx {
 }
 
 /// Context provided to the uninstall function of [`ServiceManager`]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceUninstallCtx {
     /// Label associated with the service
     ///
@@ -252,6 +254,7 @@ pub struct ServiceUninstallCtx {
 }
 
 /// Context provided to the start function of [`ServiceManager`]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceStartCtx {
     /// Label associated with the service
     ///
@@ -260,6 +263,7 @@ pub struct ServiceStartCtx {
 }
 
 /// Context provided to the stop function of [`ServiceManager`]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceStopCtx {
     /// Label associated with the service
     ///


### PR DESCRIPTION
We have a thin wrapper around your library which would allow us to mock test our code. But unfortunately, `mock_all` requires us to implement certain traits on the arguments. 

The structs use basic types for its field and there is no sensitive items under it, so I felt it was okay to add Clone and Debug there. Please let me know if there are any concerns when deriving those traits.