### PR TITLE
Remove user for user level service in Systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issue where calling stop on MacOS service does not halt the service due to the service's default auto-restart setting. (#19)
 
+## [0.6.1] - 2024-05-01
+
+- Remove user specification for user-mode service definitions in Systemd. In a user-mode service, it will run as the current user, and the service won't actually start correctly if the user is specified. The user specification is really for system-wide services that don't run as root.
+
 ## [0.6.0] - 2024-02-18
 
 - Derive basic traits on the Service context structs. (#18)

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -290,8 +290,15 @@ fn make_service(
     if let Some(x) = restart_sec {
         let _ = writeln!(service, "RestartSec={x}");
     }
-    if let Some(username) = &ctx.username {
-        let _ = writeln!(service, "User={username}");
+
+    // For Systemd, a user-mode service definition should *not* specify the username, since it runs
+    // as the current user. The service will not start correctly if the definition specifies the
+    // username, even if it's the same as the current user. The option for specifying a user really
+    // only applies for a system-level service that doesn't run as root.
+    if !user {
+        if let Some(username) = &ctx.username {
+            let _ = writeln!(service, "User={username}");
+        }
     }
 
     let _ = writeln!(service, "[Install]");


### PR DESCRIPTION
For Systemd, user-mode services should not specify the user as part of their service definition. If the user is included, the service won't actually start correctly.

The user option is for running system-level services as a non-root user.

I am going to get a colleague to test this on macOS to see if Launchd services also need the user omitted for user-mode services.