### PR TITLE
Introduce `autostart` field on `ServiceInstallCtx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2024-05-29
+
+- The WinSW service manager can read the location of the WinSW binary from the `WINSW_PATH`
+environment variable
+
 ## [0.6.2] - 2024-05-27
 
 - The WinSW service manager will delete service directories upon uninstall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.3] - 2024-05-29
+## [0.7.0] - 2024-05-30
+
+### Added
 
 - The WinSW service manager can read the location of the WinSW binary from the `WINSW_PATH`
-environment variable
+  environment variable. This is useful to avoid the necessity of having it in a location that is on
+  the `Path` variable, which can be a bit more awkward on Windows. There are a lack of standard
+  locations that can be written to without administrative privileges.
+- Introduce the `autostart` field on `ServiceInstallCtx`. This controls whether a service should
+  automatically start upon rebooting the OS. It's an option common to all service managers and it's
+  useful for developers to think about whether their services should automatically start up. If the
+  service is resource intensive or uses a lot of bandwidth, some users actually don't want automatic
+  start because it can potentially render their machine unusable.
 
 ## [0.6.2] - 2024-05-27
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ manager.install(ServiceInstallCtx {
     username: None, // Optional String for alternative user to run service.
     working_directory: None, // Optional String for the working directory for the service process.
     environment: None, // Optional list of environment variables to supply the service process.
+    autostart: true, // Specify whether the service should automatically start upon OS reboot.
 }).expect("Failed to install");
 
 // Start our service using the underlying service management platform
@@ -142,6 +143,7 @@ manager.install(ServiceInstallCtx {
     username: None, // Optional String for alternative user to run service.
     working_directory: None, // Optional String for the working directory for the service process.
     environment: None, // Optional list of environment variables to supply the service process.
+    autostart: true, // Specify whether the service should automatically start upon OS reboot.
 }).expect("Failed to install");
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,9 @@ pub struct ServiceInstallCtx {
     /// Optionally specify a list of environment variables to be passed to the process launched by
     /// the service
     pub environment: Option<Vec<(String, String)>>,
+
+    /// Specify whether the service should automatically start on reboot
+    pub autostart: bool,
 }
 
 impl ServiceInstallCtx {

--- a/src/openrc.rs
+++ b/src/openrc.rs
@@ -70,10 +70,14 @@ impl ServiceManager for OpenRcServiceManager {
             SCRIPT_FILE_PERMISSIONS,
         )?;
 
-        // Add with default run level explicitly defined to prevent weird systems
-        // like alpine's docker container with openrc from setting a different
-        // run level than default
-        rc_update("add", &script_name, [OsStr::new("default")])
+        if ctx.autostart {
+            // Add with default run level explicitly defined to prevent weird systems
+            // like alpine's docker container with openrc from setting a different
+            // run level than default
+            rc_update("add", &script_name, [OsStr::new("default")])?;
+        }
+
+        Ok(())
     }
 
     fn uninstall(&self, ctx: ServiceUninstallCtx) -> io::Result<()> {

--- a/src/rcd.rs
+++ b/src/rcd.rs
@@ -59,7 +59,11 @@ impl ServiceManager for RcdServiceManager {
             SCRIPT_FILE_PERMISSIONS,
         )?;
 
-        rc_d_script("enable", &service)
+        if ctx.autostart {
+            rc_d_script("enable", &service)?;
+        }
+
+        Ok(())
     }
 
     fn uninstall(&self, ctx: ServiceUninstallCtx) -> io::Result<()> {

--- a/src/sc.rs
+++ b/src/sc.rs
@@ -187,8 +187,15 @@ impl ServiceManager for ScServiceManager {
         let service_name = ctx.label.to_qualified_name();
 
         let service_type = OsString::from(self.config.install.service_type.to_string());
-        let start_type = OsString::from(self.config.install.start_type.to_string());
         let error_severity = OsString::from(self.config.install.error_severity.to_string());
+        let start_type = if ctx.autostart {
+            OsString::from("Auto")
+        } else {
+            // TODO: Perhaps it could be useful to make `start_type` an `Option`? That way you
+            // could have `Auto`/`Demand` based on `autostart`, and if `start_type` is set, its
+            // special value will override `autostart`.
+            OsString::from(self.config.install.start_type.to_string())
+        };
 
         // Build our binary including arguments, following similar approach as windows-service-rs
         let mut binpath = OsString::new();

--- a/system-tests/tests/runner.rs
+++ b/system-tests/tests/runner.rs
@@ -101,6 +101,7 @@ pub fn run_test(manager: &TypedServiceManager, username: Option<String>) -> Opti
             username: username.clone(),
             working_directory: None,
             environment: None,
+            autostart: true,
         })
         .unwrap();
 


### PR DESCRIPTION
Hey Chip,

Here is another PR with a few changes we have found necessary for using the crate in our project. We have a release we need to get out by this Monday, so if it would be possible, a quick merge and publish on this would be greatly appreciated! 

- b24eb18 **Obtain WinSW location from environment variable**

  If WinSW is not at any of the locations specified by the system or user `Path` variable, check the
  `WINSW_PATH` variable for a potential location.

  This is useful because it enables putting the WinSW binary in a location that is not on `Path`. On
  Windows, by default there are no locations on `Path` the user can write to without administrative
  privileges. Callers of the crate can obtain the WinSW binary and put it in any location they wish,
  then set `WINSW_PATH` in the same process, and not have to worry about their users not having the
  binary in a `Path` location.

- 17ad9cf **Introduce `autostart` field on `ServiceInstallCtx`**

  BREAKING CHANGE: users who upgrade will need to explicitly add an `autostart` field into their
  `ServiceInstallCtx` definition.

  This controls whether a service should automatically start upon rebooting the OS. It's an option
  common to all service managers and it's useful for developers to think about whether their services
  should automatically start up, which I think justifies the breaking change. If the service is
  resource intensive or uses a lot of bandwidth, some users actually don't want automatic start
  because it can potentially render their machine unusable.

  It could be that rc.d needs a little bit of additional work here. I am not very familiar with this
  system.
