### PR TITLE
Truncate file when opening service manifest for writing

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 /// Writes/overwrites a file, assigning the permissions of `mode` if on a unix system
 pub fn write_file(path: &Path, data: &[u8], _mode: u32) -> io::Result<()> {
     let mut opts = OpenOptions::new();
-    opts.create(true).write(true);
+    opts.create(true).write(true).truncate(true);
 
     #[cfg(unix)]
     {


### PR DESCRIPTION
When writing a service manifest to disk, the current write_file function doesnt empty the file in memory before writing to it, leading to corrupted manifests if the file on disk is longer than what is about to be written.