### PR TITLE
Add ability to specify service requires network to be running

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ manager.install(ServiceInstallCtx {
     environment: None, // Optional list of environment variables to supply the service process.
     autostart: true, // Specify whether the service should automatically start upon OS reboot.
     disable_restart_on_failure: false, // Services restart on crash by default.
+    requires_network: false, // Service does not require network to be up in order to run
 }).expect("Failed to install");
 
 // Start our service using the underlying service management platform
@@ -146,6 +147,7 @@ manager.install(ServiceInstallCtx {
     environment: None, // Optional list of environment variables to supply the service process.
     autostart: true, // Specify whether the service should automatically start upon OS reboot.
     disable_restart_on_failure: false, // Services restart on crash by default.
+    requires_network: false, // Service does not require network to be up in order to run
 }).expect("Failed to install");
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,9 @@ pub struct ServiceInstallCtx {
     ///
     /// This could overwrite the platform specific service manager config.
     pub disable_restart_on_failure: bool,
+
+    /// Specify whether the service requires network to be up and running in order to run
+    pub requires_network: bool,
 }
 
 impl ServiceInstallCtx {

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -278,8 +278,10 @@ fn make_service(
     let _ = writeln!(service, "Description={description}");
 
     if requires_network {
+        // delay the start of this service until after networking has been started
         let _ = writeln!(service, "After=network-online.target");
-        let _ = writeln!(service, "Wants=network-online.target");
+        // this service requires that networking be up and online before it is started
+        let _ = writeln!(service, "Requires=network-online.target");
     }
 
     if let Some(x) = start_limit_interval_sec {

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -144,7 +144,8 @@ impl ServiceManager for SystemdServiceManager {
                 &ctx,
                 self.user,
                 ctx.autostart,
-                ctx.disable_restart_on_failure
+                ctx.disable_restart_on_failure,
+                ctx.requires_network,
             ),
         };
 
@@ -261,7 +262,8 @@ fn make_service(
     ctx: &ServiceInstallCtx,
     user: bool,
     autostart: bool,
-    disable_restart_on_failure: bool
+    disable_restart_on_failure: bool,
+    requires_network: bool,
 ) -> String {
     use std::fmt::Write as _;
     let SystemdInstallConfig {
@@ -274,6 +276,11 @@ fn make_service(
     let mut service = String::new();
     let _ = writeln!(service, "[Unit]");
     let _ = writeln!(service, "Description={description}");
+
+    if requires_network {
+        let _ = writeln!(service, "After=network-online.target");
+        let _ = writeln!(service, "Wants=network-online.target");
+    }
 
     if let Some(x) = start_limit_interval_sec {
         let _ = writeln!(service, "StartLimitIntervalSec={x}");

--- a/src/winsw.rs
+++ b/src/winsw.rs
@@ -625,6 +625,7 @@ mod tests {
             environment: None,
             autostart: true,
             disable_restart_on_failure: false,
+            requires_network: false,
         };
 
         WinSwServiceManager::write_service_configuration(
@@ -673,6 +674,7 @@ mod tests {
             environment: None,
             autostart: false,
             disable_restart_on_failure: false,
+            requires_network: false,
         };
 
         WinSwServiceManager::write_service_configuration(
@@ -721,6 +723,7 @@ mod tests {
             environment: None,
             autostart: false,
             disable_restart_on_failure: false,
+            requires_network: false,
         };
 
         let mut config = WinSwConfig::default();
@@ -774,6 +777,7 @@ mod tests {
             ]),
             autostart: true,
             disable_restart_on_failure: false,
+            requires_network: false,
         };
 
         let config = WinSwConfig {
@@ -904,6 +908,7 @@ mod tests {
             environment: None,
             autostart: true,
             disable_restart_on_failure: false,
+            requires_network: false,
         };
 
         WinSwServiceManager::write_service_configuration(
@@ -948,6 +953,7 @@ mod tests {
             environment: None,
             autostart: true,
             disable_restart_on_failure: false,
+            requires_network: false,
         };
 
         let result = WinSwServiceManager::write_service_configuration(


### PR DESCRIPTION
Fixes https://github.com/chipsenkbeil/service-manager-rs/issues/35

Add a flag to be able to specify that the service requires network in order to run.
Each implementation will need to generate appropriate config in order to respect it.

- [x] Add flag to ServcieInstallCtx
- [x] systemd implementation generates appropriate config
- [ ] launchd  implementation generates appropriate config